### PR TITLE
Remove hardcoded URL

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Views/Dashboard.html
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Views/Dashboard.html
@@ -47,7 +47,7 @@
                         
                         <div class="umb-table-cell">
                             <span ng-show="redirect.rootNodeId">
-                                <a href="http://umbraco75.omgbacon.dk/umbraco/#/content/content/edit/{{redirect.rootNodeId}}">{{redirect.rootNodeName}}</a>
+                                <a href="/umbraco/#/content/content/edit/{{redirect.rootNodeId}}">{{redirect.rootNodeName}}</a>
                             </span>
                             <span ng-hide="redirect.rootNodeId">All sites</span>
                         </div>


### PR DESCRIPTION
If the user clicks the site node, they will get a "Not found" page because of the hardcoded URL.