### PR TITLE
Added new Editor view and controller files for picking root nodes for redirects.

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dashboards/Default.js
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dashboards/Default.js
@@ -38,6 +38,7 @@
     // Since we don't have any sorting, we can assume the added redirect will be shown last
     $scope.addRedirect = function () {
         skybrudRedirectsService.addRedirect({
+						rootNodes: $scope.rootNodes,
             callback: function () {
                 $scope.updateList(1);
             }
@@ -46,8 +47,11 @@
 
     // Opens a dialog for adding a new redirect. When a callback received, the list is updated.
     $scope.editRedirect = function (redirect) {
-        skybrudRedirectsService.editRedirect(redirect, function () {
-            $scope.updateList();
+        skybrudRedirectsService.editRedirect(redirect, {
+	        rootNodes: $scope.rootNodes,
+					callback: function () {
+		        $scope.updateList();
+	        }
         });
     };
 

--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dialogs/Redirect.js
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dialogs/Redirect.js
@@ -42,6 +42,19 @@
     }
 
     $scope.model.properties = [
+		    {
+				    alias: "rootNodeId",
+				    label: "Site",
+				    description: "Specify the site that the original URL to match from belongs to",
+				    view: "/App_Plugins/Skybrud.Umbraco.Redirects/Views/Editors/Site.html",
+						value: {
+							rootNodeId: $scope.model.redirect && $scope.model.redirect.rootId ? $scope.model.redirect.rootId : 0,
+							rootNodes: $scope.options.rootNodes
+						},
+				    validation: {
+					    mandatory: false
+				    }
+		    },
         {
             alias: "originalUrl",
             label: "Original URL",

--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Site.js
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Site.js
@@ -1,0 +1,22 @@
+﻿angular.module("umbraco").controller("SkybrudUmbracoRedirects.Editors.Site.Controller", function ($scope) {
+	
+	$scope.sitepicker = {
+		rootNodes: []
+	};
+	
+	if ($scope.model.value.rootNodes) {
+		for (var i = 0; i < $scope.model.value.rootNodes.length; i++) {
+			var rootNode = $scope.model.value.rootNodes[i];
+
+			(function (node) {
+				if (typeof node.id === "undefined") {
+					node.id = 0;
+				}
+
+				$scope.sitepicker.rootNodes.push(node);
+			})(rootNode);
+		}
+
+		$scope.model.value = $scope.model.value.rootNodeId;
+	}
+});

--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Views/Dashboard.html
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Views/Dashboard.html
@@ -40,10 +40,10 @@
                         <div class="umb-table-cell col-id">{{redirect.id}}</div>
                         
                         <div class="umb-table-cell">
-                            <span ng-show="redirect.rootNodeId">
-                                <a href="/umbraco/#/content/content/edit/{{redirect.rootNodeId}}" title="{{redirect.rootNodeName}}">{{redirect.rootNodeName}}</a>
+                            <span ng-show="redirect.rootId">
+                                <a href="/umbraco/#/content/content/edit/{{redirect.rootId}}" title="{{redirect.rootNodeName}}">{{redirect.rootNodeName}}</a>
                             </span>
-                            <span ng-hide="redirect.rootNodeId">All sites</span>
+                            <span ng-hide="redirect.rootId">All sites</span>
                         </div>
 
                         <div class="umb-table-cell">

--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Views/Editors/Site.html
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Views/Editors/Site.html
@@ -1,0 +1,3 @@
+﻿<div ng-controller="SkybrudUmbracoRedirects.Editors.Site.Controller">
+	<select style="margin-right: 10px;" ng-options="item.id as item.name for item in sitepicker.rootNodes" ng-model="model.value"></select>
+</div>

--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/package.manifest
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/package.manifest
@@ -34,16 +34,17 @@
       }
     }
   ],
-  "javascript": [
-    "/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Services/RedirectsService.js",
-    "/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dashboards/Default.js",
-    "/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dialogs/Redirect.js",
-    "/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Inbound.js",
-    "/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Destination.js",
-    "/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Outbound.js",
-    "/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/OriginalUrl.js",
-    "/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/RadioGroup.js"
-  ],
+	"javascript": [
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Services/RedirectsService.js",
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dashboards/Default.js",
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dialogs/Redirect.js",
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Inbound.js",
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Destination.js",
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Outbound.js",
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/OriginalUrl.js",
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/RadioGroup.js",
+		"/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Site.js"
+	],
   "css": [
     "/App_Plugins/Skybrud.Umbraco.Redirects/Styles/Styles.css"
   ],

--- a/src/Skybrud.Umbraco.Redirects/Controllers/Api/RedirectsController.cs
+++ b/src/Skybrud.Umbraco.Redirects/Controllers/Api/RedirectsController.cs
@@ -276,7 +276,8 @@ namespace Skybrud.Umbraco.Redirects.Controllers.Api {
                 string[] urlParts = model.OriginalUrl.Split('?');
                 string url = urlParts[0].TrimEnd('/');
                 string query = urlParts.Length == 2 ? urlParts[1] : string.Empty;
-
+				
+                redirect.RootId = model.RootNodeId;
                 redirect.Url = url;
                 redirect.QueryString = query;
                 redirect.LinkId = model.Destination.Id;

--- a/src/Skybrud.Umbraco.Redirects/Models/Options/AddRedirectOptions.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Options/AddRedirectOptions.cs
@@ -5,8 +5,8 @@ namespace Skybrud.Umbraco.Redirects.Models.Options {
     public class AddRedirectOptions {
 
         #region Properties
-
-        [JsonIgnore]
+		
+        [JsonProperty("rootNodeId")]
         public int RootNodeId { get; set; }
 
         [JsonProperty("originalurl")]

--- a/src/Skybrud.Umbraco.Redirects/Models/Options/EditRedirectOptions.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Options/EditRedirectOptions.cs
@@ -11,8 +11,8 @@ namespace Skybrud.Umbraco.Redirects.Models.Options {
 
         [JsonProperty("key")]
         public string Key { get; set; }
-
-        [JsonIgnore]
+		
+        [JsonProperty("rootNodeId")]
         public int RootNodeId { get; set; }
 
         [JsonProperty("originalurl")]


### PR DESCRIPTION
Hi @abjerner , first I want to thank you and the other contributors for putting an Umbraco 8 version of this library together as it is almost exactly what we need for a project we are working on here at KØben Digital. We have put this PR together because while this package does almost everything we need, it does not handle multi site instances at this point in time. I had a quick look and I noticed that it appeared that all that was needed to be done was to wire up the front end. Anyways, I have detailed what was done below.

The aim of the functionality proposed in this PR is to provide users with the ability to create site specific redirects in Umbraco 8 multi site instances. Most of the work was done in the front end as the backend code was already set up to work with a root node Id. All I had to do in the backend was update the AddRedirectOptions and EditRedirectOptions classes by removing the JsonIgnore attribute off RootNodeId and replace it with a JsonProperty attribute. I also had to wire up RootNodeId on EditRedirectOptions to be used on save when editing a redirect.

Also I know this might be an annoying request and one that is totally dependant on this PR meeting your requirements, but getting this merged in ASAP would be awesome as we have a project here at KØben Digital that will require this functionality in the next few weeks.