### PR TITLE
#90 - Use umbraco path from settings when calling backoffice endpoints

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dashboards/Default.js
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dashboards/Default.js
@@ -141,10 +141,12 @@
             $scope.activeFilters++;
         }
 
+        var umbracoPath = Umbraco.Sys.ServerVariables.umbracoSettings.umbracoPath;
+
         // Declare the HTTP options
         var http = $http({
             method: 'GET',
-            url: '/umbraco/backoffice/Skybrud/Redirects/GetRedirects',
+            url: `${umbracoPath}/backoffice/Skybrud/Redirects/GetRedirects`,
             params: args
         });
 

--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dialogs/Redirect.js
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Dialogs/Redirect.js
@@ -184,10 +184,12 @@
             redirect.rootNodeKey = "00000000-0000-0000-0000-000000000000";
         }
 
+        var umbracoPath = Umbraco.Sys.ServerVariables.umbracoSettings.umbracoPath;
+
         if (redirect.key) {
             $http({
                 method: "POST",
-                url: "/umbraco/backoffice/Skybrud/Redirects/EditRedirect",
+                url: `${umbracoPath}/backoffice/Skybrud/Redirects/EditRedirect`,
                 params: {
                     redirectId: redirect.key
                 },
@@ -203,7 +205,7 @@
         } else {
             $http({
                 method: "POST",
-                url: "/umbraco/backoffice/Skybrud/Redirects/AddRedirect",
+                url: `${umbracoPath}/backoffice/Skybrud/Redirects/AddRedirect`,
                 data: redirect
             }).then(function (r) {
                 $scope.loading = false;

--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Inbound.js
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Controllers/Editors/Inbound.js
@@ -102,10 +102,12 @@
 
         $scope.loading = true;
 
+        var umbracoPath = Umbraco.Sys.ServerVariables.umbracoSettings.umbracoPath;
+
         // Make the call to the redirects API
         var http = $http({
             method: 'GET',
-            url: '/umbraco/backoffice/Skybrud/Redirects/GetRedirectsFor' + $scope.type,
+            url: `${umbracoPath}/backoffice/Skybrud/Redirects/GetRedirectsFor` + $scope.type,
             params: {
                 contentId: $routeParams.id
             }

--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Services/RedirectsService.js
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Scripts/Services/RedirectsService.js
@@ -118,9 +118,10 @@
         },
 
         deleteRedirect: function (redirect, success, failed) {
+            var umbracoPath = Umbraco.Sys.ServerVariables.umbracoSettings.umbracoPath;
             $http({
                 method: "GET",
-                url: "/umbraco/backoffice/Skybrud/Redirects/DeleteRedirect",
+                url: `${umbracoPath}/backoffice/Skybrud/Redirects/DeleteRedirect`,
                 params: {
                     redirectId: redirect.key
                 }
@@ -158,7 +159,8 @@
     };
 
     service.getRootNodes = function () {
-        return $http.get("/umbraco/backoffice/Skybrud/Redirects/GetRootNodes");
+      var umbracoPath = Umbraco.Sys.ServerVariables.umbracoSettings.umbracoPath;
+      return $http.get(`${umbracoPath}/backoffice/Skybrud/Redirects/GetRootNodes`);
     };
 
     return service;


### PR DESCRIPTION
This fixes an issue where if the backoffice URL is renamed from ~/umbraco to ~/something-secret then any get/post to the backoffice API endpoints will fail.