### PR TITLE
Updated RedirectsMiddleware 404 detection logic to use Response.OnStarting

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/Middleware/RedirectsMiddleware.cs
+++ b/src/Skybrud.Umbraco.Redirects/Middleware/RedirectsMiddleware.cs
@@ -4,20 +4,16 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Skybrud.Umbraco.Redirects.Models;
 using Skybrud.Umbraco.Redirects.Services;
-using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Core.Web;
 
 namespace Skybrud.Umbraco.Redirects.Middleware {
     
     public class RedirectsMiddleware {
         
         private readonly RequestDelegate _next;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly IRedirectsService _redirectsService;
 
-        public RedirectsMiddleware(RequestDelegate next, IUmbracoContextAccessor umbracoContextAccessor, IRedirectsService redirectsService) {
+        public RedirectsMiddleware(RequestDelegate next, IRedirectsService redirectsService) {
             _next = next;
-            _umbracoContextAccessor = umbracoContextAccessor;
             _redirectsService = redirectsService;
         }
 
@@ -30,28 +26,24 @@ namespace Skybrud.Umbraco.Redirects.Middleware {
                 await _next(context);
                 return;
             }
-            
-            // Get a reference to the published request (may be null)
-            var publishedRequest = _umbracoContextAccessor?.UmbracoContext?.PublishedRequest;
 
-            // If we're inside the Umbraco request pipeline, and an IPublishedContent has been set, we don't do anything
-            if (publishedRequest is not null && publishedRequest.HasPublishedContent()) {
-                await _next(context);
-                return;
-            }
-                
-            // Look for a redirect
-            Redirect redirect = _redirectsService.GetRedirectByRequest(context.Request);
+            context.Response.OnStarting(() => {
+                if (context.Response.StatusCode == StatusCodes.Status404NotFound)
+                {
+                    // Look for a redirect
+                    Redirect redirect = _redirectsService.GetRedirectByRequest(context.Request);
 
-            // Carry on like normal if no matching redirects are found
-            if (redirect == null) {
-                await _next(context);
-                return;
-            }
-            
-            // Redirect the user to the destination URL
-            context.Response.Redirect(redirect.Destination.Url);
+                    if (redirect != null)
+                    {
+                        // Redirect the user to the destination URL
+                        context.Response.Redirect(redirect.Destination.Url);
+                    }
+                }
 
+                return Task.CompletedTask;
+            });
+
+            await _next(context);
         }
 
     }


### PR DESCRIPTION
This will allow redirects to still work even if a ContentFinder is used to display custom 404 pages for example.

It also makes the code a bit more straightforward and brings it more in line with the v8 version of the package.