### PR TITLE
allows redirecting when Error404Collection is set up

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/Middleware/RedirectsMiddleware.cs
+++ b/src/Skybrud.Umbraco.Redirects/Middleware/RedirectsMiddleware.cs
@@ -66,7 +66,7 @@ namespace Skybrud.Umbraco.Redirects.Middleware {
             // we don't do anything except a 404 status is set
             // 404 is set, when Umbraco found a custom 404 page
             // if no redirect is set up, custom 404 page will still be shown ( see redirect equals null condition above)
-            return publishedRequest?.ResponseStatusCode != 404 && publishedRequest.HasPublishedContent();
+            return publishedRequest?.ResponseStatusCode != 404 && publishedRequest?.HasPublishedContent() == true;
         }
 
     }


### PR DESCRIPTION
I've implemented another approach in regards of  
https://our.umbraco.com/forum/umbraco-9/107293-skybrud-redirects-does-not-redirect-when-error404collection-is-set-up  
and  
https://github.com/skybrud/Skybrud.Umbraco.Redirects/pull/97  

This does only small changes to existing logic, but now test for published content will only pass if status code is different to 404  
This allows setting up custom error pages in CMS