### PR TITLE
Added missing ForwardQueryString check to GetRedirectByPathAndQuery

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/Middleware/RedirectsMiddleware.cs
+++ b/src/Skybrud.Umbraco.Redirects/Middleware/RedirectsMiddleware.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
+using Skybrud.Umbraco.Redirects.Extensions;
 using Skybrud.Umbraco.Redirects.Models;
 using Skybrud.Umbraco.Redirects.Services;
 using Umbraco.Cms.Core;
@@ -46,20 +47,25 @@ namespace Skybrud.Umbraco.Redirects.Middleware {
                         
                         // Look for a redirect
                         IRedirect redirect = _redirectsService.GetRedirectByRequest(context.Request);
-                    
-                        // Respond with a redirect based on the redirect type
-                        switch (redirect?.Type) {
 
-                            // If redirect is of type permanent, trigger a 301 redirect
-                            case RedirectType.Permanent:
-                                context.Response.Redirect(redirect.Destination.Url, true);
-                                break;
-                                    
-                            // If redirect is of type temporary, trigger a 307 redirect
-                            case RedirectType.Temporary:
-                                context.Response.Redirect(redirect.Destination.Url, false, true);
-                                break;
-                            
+                        if (redirect != null) {
+
+                            string destinationUrl = _redirectsService.GetDestinationUrl(redirect, context.Request.GetUri().PathAndQuery);
+
+                            // Respond with a redirect based on the redirect type
+                            switch (redirect.Type) {
+
+                                // If redirect is of type permanent, trigger a 301 redirect
+                                case RedirectType.Permanent:
+                                    context.Response.Redirect(destinationUrl, true);
+                                    break;
+
+                                // If redirect is of type temporary, trigger a 307 redirect
+                                case RedirectType.Temporary:
+                                    context.Response.Redirect(destinationUrl, false, true);
+                                    break;
+
+                            }
                         }
 
                         break;

--- a/src/Skybrud.Umbraco.Redirects/Services/IRedirectsService.cs
+++ b/src/Skybrud.Umbraco.Redirects/Services/IRedirectsService.cs
@@ -42,7 +42,7 @@ namespace Skybrud.Umbraco.Redirects.Services {
         IRedirect GetRedirectById(int redirectId);
 
         /// <summary>
-        /// Gets the redirect mathing the specified GUID <paramref name="key"/>.
+        /// Gets the redirect matching the specified GUID <paramref name="key"/>.
         /// </summary>
         /// <param name="key">The GUID key of the redirect.</param>
         /// <returns>An instance of <see cref="IRedirect"/>, or <c>null</c> if not found.</returns>
@@ -57,12 +57,13 @@ namespace Skybrud.Umbraco.Redirects.Services {
         IRedirect GetRedirectByUrl(Guid rootNodeKey, string url);
         
         /// <summary>
-        /// Gets the redirect mathing the specified <paramref name="url"/> and <paramref name="queryString"/>.
+        /// Gets the redirect matching the specified <paramref name="url"/> and <paramref name="queryString"/>.
         /// </summary>
         /// <param name="rootNodeKey">The GUID of the root/side node. Use <see cref="Guid.Empty"/> for a global redirect.</param>
         /// <param name="url">The URL of the redirect.</param>
         /// <param name="queryString">The query string of the redirect.</param>
         /// <returns>An instance of <see cref="IRedirect"/>, or <c>null</c> if not found.</returns>
+        [Obsolete("Use GetRedirectByPathAndQuery")]
         IRedirect GetRedirectByUrl(Guid rootNodeKey, string url, string queryString);
 
         /// <summary>


### PR DESCRIPTION
GetRedirectByPathAndQuery(guid, string, string) appears to do the same thing as GetRedirectByUrl(guid, string, string) assuming some logic is unintentially missing, so added the fallback ForwardQueryString check. Consolidated the methods and marked GetRedirectByUrl(guid, string, string)  as obsolete.

That exposed no code calling the GetDestinationUrl which critically merges the query string parameters so added that to the middleware.

Appears to fix #43 and possibly #104