### PR TITLE
Added missing ForwardQueryString check to GetRedirectByPathAndQuery

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/Services/IRedirectsService.cs
+++ b/src/Skybrud.Umbraco.Redirects/Services/IRedirectsService.cs
@@ -58,16 +58,6 @@ namespace Skybrud.Umbraco.Redirects.Services {
         IRedirect GetRedirectByUrl(Guid rootNodeKey, string url);
         
         /// <summary>
-        /// Gets the redirect mathing the specified <paramref name="url"/> and <paramref name="queryString"/>.
-        /// </summary>
-        /// <param name="rootNodeKey">The GUID of the root/side node. Use <see cref="Guid.Empty"/> for a global redirect.</param>
-        /// <param name="url">The URL of the redirect.</param>
-        /// <param name="queryString">The query string of the redirect.</param>
-        /// <returns>An instance of <see cref="IRedirect"/>, or <c>null</c> if not found.</returns>
-        [Obsolete("Use GetRedirectByPathAndQuery")]
-        IRedirect GetRedirectByUrl(Guid rootNodeKey, string url, string queryString);
-
-        /// <summary>
         /// Returns the redirect matching the specified <paramref name="path"/> and <paramref name="query"/>, or <c>null</c> if not redirect is found.
         /// </summary>
         /// <param name="rootNodeKey">The GUID of the root/side node. Use <see cref="Guid.Empty"/> for a global redirect.</param>

--- a/src/Skybrud.Umbraco.Redirects/Services/IRedirectsService.cs
+++ b/src/Skybrud.Umbraco.Redirects/Services/IRedirectsService.cs
@@ -64,6 +64,7 @@ namespace Skybrud.Umbraco.Redirects.Services {
         /// <param name="url">The URL of the redirect.</param>
         /// <param name="queryString">The query string of the redirect.</param>
         /// <returns>An instance of <see cref="IRedirect"/>, or <c>null</c> if not found.</returns>
+        [Obsolete("Use GetRedirectByPathAndQuery")]
         IRedirect GetRedirectByUrl(Guid rootNodeKey, string url, string queryString);
 
         /// <summary>

--- a/src/Skybrud.Umbraco.Redirects/Services/RedirectsService.cs
+++ b/src/Skybrud.Umbraco.Redirects/Services/RedirectsService.cs
@@ -237,18 +237,6 @@ namespace Skybrud.Umbraco.Redirects.Services {
 
         }
 
-        /// <summary>
-        /// Gets the redirect mathing the specified <paramref name="url"/> and <paramref name="queryString"/>.
-        /// </summary>
-        /// <param name="rootNodeKey">The key of the root/side node. Use <c>0</c> for a global redirect.</param>
-        /// <param name="url">The URL of the redirect.</param>
-        /// <param name="queryString">The query string of the redirect.</param>
-        /// <returns>An instance of <see cref="Redirect"/>, or <c>null</c> if not found.</returns>
-        [Obsolete("Use GetRedirectByPathAndQuery")]
-        public IRedirect GetRedirectByUrl(Guid rootNodeKey, string url, string queryString) {
-            return GetRedirectByPathAndQuery(rootNodeKey, url, queryString);
-        }
-
         /// <inheritdoc />
         public IRedirect AddRedirect(AddRedirectOptions options) {
 


### PR DESCRIPTION
GetRedirectByPathAndQuery(guid, string, string) does the same thing as GetRedirectByUrl(guid, string, string) so consolidated the logic variations, added the fallback ForwardQueryString check, and marked GetRedirectByUrl(guid, string, string)  as obsolete.

Fixes #128 and along with other recent code should fix #43 and #104