### PR TITLE
Fix destination property label for en-US

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Lang/en-US.xml
+++ b/src/Skybrud.Umbraco.Redirects/App_Plugins/Skybrud.Umbraco.Redirects/Lang/en-US.xml
@@ -91,7 +91,7 @@
     <key alias="propertySiteDescription">Select the site (or root node) the redirect should apply to. If a site is not selected, the redirect will apply to all domains/sites in the Umbraco solution.</key>
     <key alias="propertyOriginalUrl">Original URL</key>
     <key alias="propertyOriginalUrlDescription">Specify the original URL to match from which the user should be redirected to the destination.</key>
-    <key alias="propertyDestination">Original URL</key>
+    <key alias="propertyDestination">Destination</key>
     <key alias="propertyDestinationDescription">Select the page or URL the user should be redirected to.</key>
     <key alias="propertyRedirectTypeName">Redirect type</key>
     <key alias="propertyRedirectTypeDescription">Select the type of the redirect. Notice that browsers will remember permanent redirects.</key>


### PR DESCRIPTION
I noticed the label for the "Destination" property when creating a redirect is wrong for the en-US culture.

It shows "Original URL" instead, clearly a copy-paste error as it's correct for the DK culture and was correct in previous versions of Skybrud Redirects 😊

<img width="761" alt="Screenshot 2022-04-20 at 12 49 56" src="https://user-images.githubusercontent.com/16511093/164224159-ab048e45-ea62-4502-9a25-c27010b26842.png">

Fixed!