### PR TITLE
Redirects created with trailing / don't work

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/Models/Redirect.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Redirect.cs
@@ -50,7 +50,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
         [JsonProperty("path")]
         public string Path {
             get => Dto.Path;
-            set => Dto.Path = value;
+            set => Dto.Path = value?.TrimEnd('/');
         }
 
         /// <summary>
@@ -80,9 +80,9 @@ namespace Skybrud.Umbraco.Redirects.Models {
                 // Split the path and query
                 value.Split('?', out string path, out string query);
 
-                // Update the DTO properties
-                Dto.Path = path.TrimEnd('/');
-                Dto.QueryString = query;
+                // Update the path and query
+                Path = path;
+                QueryString = query ?? string.Empty;
 
             }
 

--- a/src/Skybrud.Umbraco.Redirects/Models/Redirect.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Redirect.cs
@@ -81,7 +81,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
                 value.Split('?', out string path, out string query);
 
                 // Update the DTO properties
-                Dto.Path = path;
+                Dto.Path = path.TrimEnd('/');
                 Dto.QueryString = query;
 
             }

--- a/src/Skybrud.Umbraco.Redirects/Services/RedirectsService.cs
+++ b/src/Skybrud.Umbraco.Redirects/Services/RedirectsService.cs
@@ -265,8 +265,9 @@ namespace Skybrud.Umbraco.Redirects.Services {
 
             if (options == null) throw new ArgumentNullException(nameof(options));
 
-            string url = options.OriginalUrl;
-            string query = string.Empty;
+            string[] urlParts = options.OriginalUrl.Split('?');
+            string url = urlParts[0].TrimEnd('/');
+            string query = urlParts.Length == 2 ? urlParts[1] : string.Empty;
 
             if (GetRedirectByPathAndQuery(options.RootNodeKey, url, query) != null) {
                 throw new RedirectsException("A redirect with the specified URL already exists.");


### PR DESCRIPTION
As discussed on issue #132 the redirects created via the backoffice currently don't work until they are resaved. This is because the trailing slashes are stripped from URLs on save, but not on create.

I'm not 100% sure why the trailing slashes are stripped, but in this PR I have at least aimed to make the behaviour more consistent.

After these changes the setter on [`Redirect`](https://github.com/skybrud/Skybrud.Umbraco.Redirects/blob/v3/main/src/Skybrud.Umbraco.Redirects/Models/Redirect.cs)'s `Url` property will also correctly strip any trailing slashes. This arguably makes manually splitting the `OriginalUrl` in the `EditRedirect` controller methods irrelevant, as the service layer will handle it. It leaves manually splitting the URL to get the query string only truly necessary when calling `GetRedirectByPathAndQuery` (which the service does internally). I felt this was a little too far within this specific PR, but will happily make another if you think this is valuable!

_BTW I **love** the `Split(separator, out, out)` extension method idea you've got here, please consider putting that in the Skybrud Essentials library if it isn't there already 😁_