### PR TITLE
Fixes model property names not being serialized properly

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/Helpers/RedirectsBackOfficeHelper.cs
+++ b/src/Skybrud.Umbraco.Redirects/Helpers/RedirectsBackOfficeHelper.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Skybrud.Essentials.Reflection;
-using Skybrud.Essentials.Strings;
 using Skybrud.Essentials.Strings.Extensions;
 using Skybrud.Umbraco.Redirects.Config;
 using Skybrud.Umbraco.Redirects.Dashboards;
@@ -181,10 +180,7 @@ namespace Skybrud.Umbraco.Redirects.Helpers {
             IEnumerable<RedirectModel> items = result.Items
                 .Select(redirect => Map(redirect, rootNodeLookup, contentLookup, mediaLookup, languageLookup));
 
-            return new {
-                result.Pagination,
-                items
-            };
+            return new RedirectList(result.Pagination, items);
 
         }
 

--- a/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectDestinationModel.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectDestinationModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Umbraco.Cms.Core.Models;
 
 #pragma warning disable 1591
@@ -10,36 +11,59 @@ namespace Skybrud.Umbraco.Redirects.Models.Api {
 
         private readonly IRedirectDestination _destination;
 
+        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id => _destination.Id;
 
+        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public Guid Key => _destination.Key;
 
+        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
 
+        [JsonProperty("query")]
+        [JsonPropertyName("query")]
         public string Query => _destination.Query;
 
+        [JsonProperty("fragment")]
+        [JsonPropertyName("fragment")]
         public string Fragment => _destination.Fragment;
 
+        [JsonProperty("displayUrl")]
+        [JsonPropertyName("displayUrl")]
         public string DisplayUrl => RedirectsUtils.ConcatUrl(Url, Query, Fragment);
 
+        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
+        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public string Icon { get; }
 
+        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public RedirectDestinationType Type => _destination.Type;
 
+        [JsonProperty("null")]
         [JsonPropertyName("null")]
         public bool IsNull { get; }
 
+        [JsonProperty("trashed")]
         [JsonPropertyName("trashed")]
         public bool IsTrashed { get; }
 
+        [JsonProperty("published")]
         [JsonPropertyName("published")]
         public bool IsPublished { get; }
 
+        [JsonProperty("backofficeUrl")]
         [JsonPropertyName("backOfficeUrl")]
         public string? BackOfficeUrl { get; set; }
 
+        [JsonProperty("warning")]
         [JsonPropertyName("warning")]
         public string? Warning {
             get {
@@ -50,9 +74,11 @@ namespace Skybrud.Umbraco.Redirects.Models.Api {
             }
         }
 
+        [JsonProperty("culture")]
         [JsonPropertyName("culture")]
         public string? Culture { get; set; }
 
+        [JsonProperty("cultureName")]
         [JsonPropertyName("cultureName")]
         public string? CultureName { get; set; }
 

--- a/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectDestinationModel.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectDestinationModel.cs
@@ -59,7 +59,7 @@ namespace Skybrud.Umbraco.Redirects.Models.Api {
         [JsonPropertyName("published")]
         public bool IsPublished { get; }
 
-        [JsonProperty("backofficeUrl")]
+        [JsonProperty("backOfficeUrl")]
         [JsonPropertyName("backOfficeUrl")]
         public string? BackOfficeUrl { get; set; }
 

--- a/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectList.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectList.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+
+namespace Skybrud.Umbraco.Redirects.Models.Api {
+
+    public class RedirectList {
+
+        [JsonProperty("pagination")]
+        [JsonPropertyName("pagination")]
+        public RedirectsSearchResultPagination Pagination { get; }
+
+        [JsonProperty("items")]
+        [JsonPropertyName("items")]
+        public IEnumerable<RedirectModel> Items { get; }
+
+        public RedirectList(RedirectsSearchResultPagination pagination, IEnumerable<RedirectModel> items) {
+            Pagination = pagination;
+            Items = items;
+        }
+
+    }
+
+}

--- a/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectModel.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Skybrud.Essentials.Time;
 using Skybrud.Umbraco.Redirects.Text.Json;
 
@@ -11,31 +12,53 @@ namespace Skybrud.Umbraco.Redirects.Models.Api {
 
         private readonly IRedirect _redirect;
 
+        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id => _redirect.Id;
 
+        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public Guid Key => _redirect.Key;
 
+        [JsonProperty("rootNode")]
+        [JsonPropertyName("rootNode")]
         public RedirectRootNodeModel? RootNode { get; }
 
+        [JsonProperty("path")]
+        [JsonPropertyName("path")]
         public string Path => _redirect.Path;
 
+        [JsonProperty("queryString")]
+        [JsonPropertyName("queryString")]
         public string QueryString => _redirect.QueryString;
 
+        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url => _redirect.Url;
 
+        [JsonProperty("destination")]
+        [JsonPropertyName("destination")]
         public RedirectDestinationModel Destination { get; }
 
-        [JsonConverter(typeof(Iso8601TimeConverter))]
+        [JsonProperty("createDate")]
+        [JsonPropertyName("createDate")]
+        [System.Text.Json.Serialization.JsonConverter(typeof(Iso8601TimeConverter))]
         public EssentialsTime CreateDate => _redirect.CreateDate;
 
-        [JsonConverter(typeof(Iso8601TimeConverter))]
+        [JsonProperty("updateDate")]
+        [JsonPropertyName("updateDate")]
+        [System.Text.Json.Serialization.JsonConverter(typeof(Iso8601TimeConverter))]
         public EssentialsTime UpdateDate => _redirect.UpdateDate;
 
+        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public RedirectType Type => _redirect.Type;
 
+        [JsonProperty("permanent")]
         [JsonPropertyName("permanent")]
         public bool IsPermanent => _redirect.IsPermanent;
 
+        [JsonProperty("forward")]
         [JsonPropertyName("forward")]
         public bool ForwardQueryString => _redirect.ForwardQueryString;
 

--- a/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectNodeModel.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectNodeModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -12,20 +13,32 @@ namespace Skybrud.Umbraco.Redirects.Models.Api {
 
     public class RedirectNodeModel {
 
+        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id { get; }
 
+        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public Guid Key { get; }
 
+        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; }
 
+        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string? Url { get; }
 
+        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         [MicrosoftJsonConverter(typeof(Text.Json.Enums.EnumCamelCaseConverter))]
         public RedirectDestinationType Type { get; }
 
+        [JsonProperty("publised")]
         [JsonPropertyName("published")]
         public bool IsPublished { get; }
 
+        [JsonProperty("trashed")]
         [JsonPropertyName("trashed")]
         public bool IsTrashed { get; }
 

--- a/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectRootNodeModel.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Api/RedirectRootNodeModel.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Skybrud.Umbraco.Redirects.Helpers;
 using Umbraco.Cms.Core.Models;
 
@@ -8,16 +10,28 @@ namespace Skybrud.Umbraco.Redirects.Models.Api {
 
     public class RedirectRootNodeModel {
 
+        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id { get; }
 
+        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public Guid Key { get; }
 
+        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string? Name { get; }
 
+        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public string? Icon { get; }
 
+        [JsonProperty("backofficeUrl")]
+        [JsonPropertyName("backofficeUrl")]
         public string? BackOfficeUrl { get; }
 
+        [JsonProperty("domains")]
+        [JsonPropertyName("domains")]
         public string[] Domains { get; }
 
         public RedirectRootNodeModel(IRedirect redirect, IContent? content, string[]? domains, string backOfficeBaseUrl) {

--- a/src/Skybrud.Umbraco.Redirects/Models/IRedirect.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/IRedirect.cs
@@ -15,41 +15,49 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets the ID of the redirect.
         /// </summary>
         [JsonProperty("id")]
+        [JsonPropertyName("id")]
         int Id { get; }
 
         /// <summary>
         /// Gets the unique ID of the redirect.
         /// </summary>
         [JsonProperty("key")]
+        [JsonPropertyName("key")]
         Guid Key { get; }
 
         /// <summary>
         /// Gets or sets the root node key of the redirect.
         /// </summary>
         [JsonProperty("rootKey")]
+        [JsonPropertyName("rootKey")]
         Guid RootKey { get; set; }
 
         /// <summary>
         /// Gets or sets the inbound path of the redirect. The value value will not contain the domain or the query string.
         /// </summary>
         [JsonProperty("path")]
+        [JsonPropertyName("path")]
         string Path { get; set; }
 
         /// <summary>
         /// Gets or sets the inbound query string of the redirect.
         /// </summary>
         [JsonProperty("queryString")]
+        [JsonPropertyName("queryString")]
         string QueryString { get; set; }
 
         /// <summary>
         /// Gets or sets the inbound URL of the redirect.
         /// </summary>
         [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the destination of the redirect.
         /// </summary>
+        [JsonProperty("destination")]
+        [JsonPropertyName("destination")]
         public new IRedirectDestination Destination { get; set; }
 
         /// <summary>
@@ -77,6 +85,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets or sets the timestamp for when the redirect was created.
         /// </summary>
         [JsonProperty("createDate", Order = 100)]
+        [JsonPropertyName("createDate")]
         [System.Text.Json.Serialization.JsonConverter(typeof(Iso8601TimeConverter))]
         public EssentialsTime CreateDate { get; }
 
@@ -84,6 +93,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets or sets the timestamp for when the redirect was last updated.
         /// </summary>
         [JsonProperty("updateDate", Order = 101)]
+        [JsonPropertyName("updateDate")]
         [System.Text.Json.Serialization.JsonConverter(typeof(Iso8601TimeConverter))]
         public EssentialsTime UpdateDate { get; set; }
 

--- a/src/Skybrud.Umbraco.Redirects/Models/IRedirectDestination.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/IRedirectDestination.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Skybrud.Umbraco.Redirects.Models {
@@ -12,60 +13,70 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets the ID of the selected content or media. If an URL has been selected, this will return <c>0</c>.
         /// </summary>
         [JsonProperty("id")]
+        [JsonPropertyName("id")]
         int Id { get; set; }
 
         /// <summary>
         /// Gets the GUID key of the selected content or media. If an URL has been selected, this will return <c>null</c>.
         /// </summary>
         [JsonProperty("key")]
+        [JsonPropertyName("key")]
         Guid Key { get; set; }
 
         /// <summary>
         /// Gets the name of the destination.
         /// </summary>
         [JsonProperty("name")]
+        [JsonPropertyName("name")]
         string Name { get; set; }
 
         /// <summary>
         /// Gets the URL of the destination.
         /// </summary>
         [JsonProperty("url")]
+        [JsonPropertyName("url")]
         string Url { get; set; }
 
         /// <summary>
         /// Gets the query string part of the destination.
         /// </summary>
         [JsonProperty("query")]
+        [JsonPropertyName("query")]
         string Query { get; set; }
 
         /// <summary>
         /// Gets the fragment of the destination - eg. <c>#hello</c>.
         /// </summary>
         [JsonProperty("fragment")]
+        [JsonPropertyName("fragment")]
         string Fragment { get; set; }
 
         /// <summary>
         /// Gets the full destination URL.
         /// </summary>
         [JsonProperty("fullUrl")]
+        [JsonPropertyName("fullUrl")]
         string FullUrl { get; }
 
         /// <summary>
         /// Gets the type of the destination.
         /// </summary>
         [JsonProperty("type")]
+        [JsonPropertyName("type")]
         RedirectDestinationType Type { get; set; }
 
         /// <summary>
         /// Gets whether the link is valid.
         /// </summary>
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         bool IsValid { get; }
 
         /// <summary>
         /// Gets the culture of the destination, if any.
         /// </summary>
         [JsonProperty("culture")]
+        [JsonPropertyName("culture")]
         public string? Culture => null;
 
     }

--- a/src/Skybrud.Umbraco.Redirects/Models/Options/AddRedirectOptions.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Options/AddRedirectOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Skybrud.Umbraco.Redirects.Models.Options {
@@ -15,36 +16,42 @@ namespace Skybrud.Umbraco.Redirects.Models.Options {
         /// the same <see cref="RootNodeId"/>, <see cref="RootNodeKey"/> and <see cref="OriginalUrl"/>.
         /// </summary>
         [JsonProperty("overwrite", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonPropertyName("overwrite")]
         public bool Overwrite { get; set; }
 
         /// <summary>
         /// Gets or set the root node ID of the redirect.
         /// </summary>
         [JsonProperty("rootNodeId")]
+        [JsonPropertyName("rootNodeId")]
         public int RootNodeId { get; set; }
 
         /// <summary>
         /// Gets or set the root node key of the redirect.
         /// </summary>
         [JsonProperty("rootNodeKey")]
+        [JsonPropertyName("rootNodeKey")]
         public Guid RootNodeKey { get; set; }
 
         /// <summary>
         /// Gets or set the original URL the redirect.
         /// </summary>
         [JsonProperty("originalUrl")]
+        [JsonPropertyName("originalUrl")]
         public string? OriginalUrl { get; set; }
 
         /// <summary>
         /// Gets or set the destination of the redirect.
         /// </summary>
         [JsonProperty("destination")]
+        [JsonPropertyName("destination")]
         public RedirectDestination Destination { get; set; } = null!;
 
         /// <summary>
         /// Gets or set whether the redirect is permanent.
         /// </summary>
         [JsonProperty("permanent")]
+        [JsonPropertyName("permanent")]
         [Obsolete("Use 'Type' property instead.")]
         public bool IsPermanent {
             get => Type == RedirectType.Permanent;
@@ -55,12 +62,14 @@ namespace Skybrud.Umbraco.Redirects.Models.Options {
         /// Gets or sets the type of the redirect - eg. <see cref="RedirectType.Permanent"/> or <see cref="RedirectType.Temporary"/>.
         /// </summary>
         [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public RedirectType Type { get; set; }
 
         /// <summary>
         /// Gets or sets whether query string forwarding should be enabled for the redirect.
         /// </summary>
         [JsonProperty("forward")]
+        [JsonPropertyName("forward")]
         public bool ForwardQueryString { get; set; }
 
         #endregion

--- a/src/Skybrud.Umbraco.Redirects/Models/Options/EditRedirectOptions.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Options/EditRedirectOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Skybrud.Umbraco.Redirects.Models.Options {
@@ -14,48 +15,56 @@ namespace Skybrud.Umbraco.Redirects.Models.Options {
         /// Gets or sets the numeric ID of the redirect.
         /// </summary>
         [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id { get; set; }
 
         /// <summary>
         /// Gets or sets the key of the redirect.
         /// </summary>
         [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string? Key { get; set; }
 
         /// <summary>
         /// Gets or set the root node ID of the redirect.
         /// </summary>
         [JsonProperty("rootNodeId")]
+        [JsonPropertyName("rootNodeId")]
         public int RootNodeId { get; set; }
 
         /// <summary>
         /// Gets or set the root node key of the redirect.
         /// </summary>
         [JsonProperty("rootNodeKey")]
+        [JsonPropertyName("rootNodeKey")]
         public Guid RootNodeKey { get; set; }
 
         /// <summary>
         /// Gets or set the original URL the redirect.
         /// </summary>
-        [JsonProperty("originalurl")]
+        [JsonProperty("originalUrl")]
+        [JsonPropertyName("originalUrl")]
         public string? OriginalUrl { get; set; }
 
         /// <summary>
         /// Gets or set the destination of the redirect.
         /// </summary>
         [JsonProperty("destination")]
+        [JsonPropertyName("destination")]
         public RedirectDestination? Destination { get; set; }
 
         /// <summary>
         /// Gets or set whether the redirect is permanent.
         /// </summary>
         [JsonProperty("permanent")]
+        [JsonPropertyName("permanent")]
         public bool IsPermanent { get; set; }
 
         /// <summary>
         /// Gets or sets whether query string forwarding should be enabled for the redirect.
         /// </summary>
         [JsonProperty("forward")]
+        [JsonPropertyName("forward")]
         public bool ForwardQueryString { get; set; }
 
         #endregion

--- a/src/Skybrud.Umbraco.Redirects/Models/Outbound/OutboundRedirect.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Outbound/OutboundRedirect.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Skybrud.Essentials.Json.Newtonsoft;
@@ -18,36 +19,42 @@ namespace Skybrud.Umbraco.Redirects.Models.Outbound {
         /// Gets whether the redirect is permanent.
         /// </summary>
         [JsonProperty("permanent")]
+        [JsonPropertyName("permanent")]
         public bool IsPermanent => Type == RedirectType.Permanent;
 
         /// <summary>
         /// Gets the type of the redirect - either <see cref="RedirectType.Permanent"/> or <see cref="RedirectType.Temporary"/>.
         /// </summary>
         [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public RedirectType Type { get; set; }
 
         /// <summary>
         /// Gets an instance of <see cref="RedirectDestination"/> representing the destination.
         /// </summary>
         [JsonProperty("destination")]
+        [JsonPropertyName("destination")]
         public IRedirectDestination Destination { get; set; }
 
         /// <summary>
         /// Gets whether the query string of the inbound request should be forwarded.
         /// </summary>
         [JsonProperty("forward")]
+        [JsonPropertyName("forward")]
         public bool ForwardQueryString { get; set; }
 
         /// <summary>
         /// Same as <see cref="IsValid"/>.
         /// </summary>
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public bool HasDestination => IsValid;
 
         /// <summary>
         /// Gets whether the redirects has a valid link.
         /// </summary>
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public bool IsValid => Destination is { IsValid: true };
 
         #endregion

--- a/src/Skybrud.Umbraco.Redirects/Models/Redirect.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Redirect.cs
@@ -27,18 +27,21 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets the ID of the redirect.
         /// </summary>
         [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id => Dto.Id;
 
         /// <summary>
         /// Gets the unique ID of the redirect.
         /// </summary>
         [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public Guid Key => Dto.Key;
 
         /// <summary>
         /// Gets or sets the root node key of the redirect.
         /// </summary>
         [JsonProperty("rootKey")]
+        [JsonPropertyName("rootKey")]
         public Guid RootKey {
             get => Dto.RootKey;
             set => Dto.RootKey = value;
@@ -48,6 +51,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets or sets the inbound path of the redirect. The value value will not contain the domain or the query string.
         /// </summary>
         [JsonProperty("path")]
+        [JsonPropertyName("path")]
         public string Path {
             get => Dto.Path;
             set => Dto.Path = value.TrimEnd('/');
@@ -57,6 +61,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets or sets the inbound query string of the redirect.
         /// </summary>
         [JsonProperty("queryString")]
+        [JsonPropertyName("queryString")]
         public string QueryString {
             get => Dto.QueryString;
             set => Dto.QueryString = value;
@@ -66,6 +71,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets or sets the inbound URL of the redirect.
         /// </summary>
         [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url {
 
             get => Dto.Path + (string.IsNullOrWhiteSpace(Dto.QueryString) ? null : "?" + QueryString);
@@ -91,6 +97,8 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// <summary>
         /// Gets or sets the destination of the redirect.
         /// </summary>
+        [JsonProperty("destination")]
+        [JsonPropertyName("destination")]
         public IRedirectDestination Destination {
 
             get => _destination;
@@ -112,6 +120,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets or sets the timestamp for when the redirect was created.
         /// </summary>
         [JsonProperty("createDate")]
+        [JsonPropertyName("createDate")]
         [System.Text.Json.Serialization.JsonConverter(typeof(Iso8601TimeConverter))]
         public EssentialsTime CreateDate {
             get => _createDate;
@@ -122,6 +131,7 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets or sets the timestamp for when the redirect was last updated.
         /// </summary>
         [JsonProperty("updateDate")]
+        [JsonPropertyName("updateDate")]
         [System.Text.Json.Serialization.JsonConverter(typeof(Iso8601TimeConverter))]
         public EssentialsTime UpdateDate {
             get => _updateDate;

--- a/src/Skybrud.Umbraco.Redirects/Models/RedirectDestination.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/RedirectDestination.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Skybrud.Essentials.Json.Extensions;
@@ -19,42 +20,49 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets the ID of the selected content or media. If an URL has been selected, this will return <c>0</c>.
         /// </summary>
         [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id { get; set; }
 
         /// <summary>
         /// Gets the GUID key of the selected content or media. If an URL has been selected, this will return <c>null</c>.
         /// </summary>
         [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public Guid Key { get; set; }
 
         /// <summary>
         /// Gets the name of the destination.
         /// </summary>
         [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets the URL of the destination.
         /// </summary>
         [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets the query string part of the destination.
         /// </summary>
         [JsonProperty("query")]
+        [JsonPropertyName("query")]
         public string Query { get; set; }
 
         /// <summary>
         /// Gets the fragment of the destination - eg. <c>#hello</c>.
         /// </summary>
         [JsonProperty("fragment")]
+        [JsonPropertyName("fragment")]
         public string Fragment { get; set; }
 
         /// <summary>
         /// Gets the full destination URL.
         /// </summary>
         [JsonProperty("fullUrl")]
+        [JsonPropertyName("fullUrl")]
         public string FullUrl {
             get {
                 StringBuilder sb = new();
@@ -74,18 +82,21 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets the type of the destination.
         /// </summary>
         [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public RedirectDestinationType Type { get; set; }
 
         /// <summary>
         /// Gets or sets the culture of the destination, if any.
         /// </summary>
         [JsonProperty("culture")]
+        [JsonPropertyName("culture")]
         public string? Culture { get; set; }
 
         /// <summary>
         /// Gets whether the link is valid.
         /// </summary>
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public bool IsValid => string.IsNullOrWhiteSpace(Url) == false;
 
         #endregion

--- a/src/Skybrud.Umbraco.Redirects/Models/RedirectDomain.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/RedirectDomain.cs
@@ -1,6 +1,7 @@
 ﻿//using Newtonsoft.Json;
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core.Models;
 
@@ -16,26 +17,29 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// <summary>
         /// Gets a reference to the underlying <see cref="IDomain"/>.
         /// </summary>
+        [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
-        [JsonIgnore]
         public IDomain Domain { get; }
 
         /// <summary>
         /// Gets the ID of the domain.
         /// </summary>
         [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id { get; }
 
         /// <summary>
         /// Gets the name of the domain.
         /// </summary>
         [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; }
 
         /// <summary>
         /// Gets the root node ID of the domain.
         /// </summary>
         [JsonProperty("rootNodeId")]
+        [JsonPropertyName("rootNodeId")]
         public int RootNodeId { get; }
 
         #endregion

--- a/src/Skybrud.Umbraco.Redirects/Models/RedirectRootNode.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/RedirectRootNode.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core.Models;
 
@@ -16,29 +17,35 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets the ID of the root node.
         /// </summary>
         [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public int Id { get; }
 
         /// <summary>
         /// Gets the GUID of the root node.
         /// </summary>
         [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public Guid Key { get; }
 
         /// <summary>
         /// Gets the name of the root node.
         /// </summary>
         [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; }
 
         /// <summary>
         /// Gets the icon of the root node.
         /// </summary>
         [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public string Icon { get; }
 
         /// <summary>
         /// Gets the domains asscoiated with the root node.
         /// </summary>
+        [JsonProperty("domains")]
+        [JsonPropertyName("domains")]
         public string[] Domains { get; }
 
         private RedirectRootNode(IContent content, IEnumerable<RedirectDomain>? domains) {

--- a/src/Skybrud.Umbraco.Redirects/Models/RedirectsSearchResult.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/RedirectsSearchResult.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Skybrud.Umbraco.Redirects.Models {
 
@@ -13,12 +14,14 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets pagination information about the collection.
         /// </summary>
         [JsonProperty("pagination")]
+        [JsonPropertyName("pagination")]
         public RedirectsSearchResultPagination Pagination { get; }
 
         /// <summary>
         /// Gets an array representing the items of the collection.
         /// </summary>
         [JsonProperty("items")]
+        [JsonPropertyName("items")]
         public IRedirect[] Items { get; }
 
         #endregion

--- a/src/Skybrud.Umbraco.Redirects/Models/RedirectsSearchResultPagination.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/RedirectsSearchResultPagination.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Skybrud.Umbraco.Redirects.Models {
@@ -14,42 +15,49 @@ namespace Skybrud.Umbraco.Redirects.Models {
         /// Gets the total amount of items across all pages.
         /// </summary>
         [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public int Total { get; }
 
         /// <summary>
         /// Gets the maximum amount of items per page.
         /// </summary>
         [JsonProperty("limit")]
+        [JsonPropertyName("limit")]
         public int Limit { get; }
 
         /// <summary>
         /// Gets the offset.
         /// </summary>
         [JsonProperty("offset")]
+        [JsonPropertyName("offset")]
         public int Offset { get; }
 
         /// <summary>
         /// Gets the current page.
         /// </summary>
         [JsonProperty("page")]
+        [JsonPropertyName("page")]
         public int Page { get; }
 
         /// <summary>
         /// Gets the total amout of pages.
         /// </summary>
         [JsonProperty("pages")]
+        [JsonPropertyName("pages")]
         public int Pages { get; }
 
         /// <summary>
         /// Gets the index of the first item on the page.
         /// </summary>
         [JsonProperty("from")]
+        [JsonPropertyName("from")]
         public int From { get; }
 
         /// <summary>
         /// Gets the index of the last item on the page.
         /// </summary>
         [JsonProperty("to")]
+        [JsonPropertyName("to")]
         public int To { get; }
 
         #endregion


### PR DESCRIPTION
When using `.AddNewtonsoftJson()` in our application we encountered that the models wasn't being serialized correctly from Skybrud.Umbraco.Redirects. This is because there was missing the `JsonProperty` attribute on the `RedirectModel`. Here `IsPermanent` and `ForwardQueryString` was serialized by those names when fetching the redirects and therefore the value was displayed incorrect when viewing a redirect in edit mode.

Therefore, I've added attributes to all models that was missing either `JsonProperty` or `JsonPropertyName` to preserve consistency in the models no matter what you're using. (System.Text.Json or Newtonsoft.Json).

I've tested this in our solution and it works with our setup.

Hope this helps @abjerner 😄 

Before:
![image](https://github.com/skybrud/Skybrud.Umbraco.Redirects/assets/24605285/2fb24e5b-c242-4d3a-984b-f179ca87a3e4)

After:
![image](https://github.com/skybrud/Skybrud.Umbraco.Redirects/assets/24605285/6a501183-3bb1-4740-a2c1-92df1d79eb15)
