### PR TITLE
Fix issues with migrations running in SQLite

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/Migrations/NullableColumnsMigration.cs
+++ b/src/Skybrud.Umbraco.Redirects/Migrations/NullableColumnsMigration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using NPoco;
 using Skybrud.Umbraco.Redirects.Models.Dtos;
 using Umbraco.Cms.Infrastructure.Migrations;
 
@@ -17,17 +18,24 @@ internal class NullableColumnsMigration : AsyncMigrationBase {
     protected override Task MigrateAsync() {
 
         try {
-
             // Save a backup of all redirects
             RedirectsUtils.SaveBackup(_webHostEnvironment, Database);
 
-            Alter
-                .Table(RedirectDto.TableName)
-                .AlterColumn(nameof(RedirectDto.QueryString)).AsString().Nullable()
-                .AlterColumn(nameof(RedirectDto.DestinationQuery)).AsString().Nullable()
-                .AlterColumn(nameof(RedirectDto.DestinationFragment)).AsString().Nullable()
-                .AlterColumn(nameof(RedirectDto.DestinationCulture)).AsString().Nullable()
-                .Do();
+            if (DatabaseType == DatabaseType.SQLite) {
+                const string oldTableName = $"{RedirectDto.TableName}Old";
+                Rename.Table(RedirectDto.TableName).To(oldTableName).Do();
+                Create.Table<RedirectDto>().Do();
+                Database.Execute($"INSERT INTO [{RedirectDto.TableName}] SELECT * FROM [{oldTableName}]");
+                Delete.Table(oldTableName).Do();
+            } else {
+                Alter
+                    .Table(RedirectDto.TableName)
+                    .AlterColumn(nameof(RedirectDto.QueryString)).AsString().Nullable()
+                    .AlterColumn(nameof(RedirectDto.DestinationQuery)).AsString().Nullable()
+                    .AlterColumn(nameof(RedirectDto.DestinationFragment)).AsString().Nullable()
+                    .AlterColumn(nameof(RedirectDto.DestinationCulture)).AsString().Nullable()
+                    .Do();
+            }
 
             Database.Execute("UPDATE [SkybrudRedirects] SET [QueryString] = null WHERE [QueryString] = '';");
             Database.Execute("UPDATE [SkybrudRedirects] SET [DestinationQuery] = null WHERE [DestinationQuery] = '';");

--- a/src/Skybrud.Umbraco.Redirects/Models/Dtos/RedirectDto.cs
+++ b/src/Skybrud.Umbraco.Redirects/Models/Dtos/RedirectDto.cs
@@ -54,6 +54,7 @@ public class RedirectDto {
     /// Gets or sets the inbound query string of the redirect.
     /// </summary>
     [Column("QueryString")]
+    [NullSetting(NullSetting = NullSettings.Null)]
     public string? QueryString { get; set; } = null!;
 
     /// <summary>
@@ -84,24 +85,28 @@ public class RedirectDto {
     /// Gets or sets the URL of the destination link.
     /// </summary>
     [Column("DestinationQuery")]
+    [NullSetting(NullSetting = NullSettings.Null)]
     public string? DestinationQuery { get; set; }
 
     /// <summary>
     /// Gets or sets the URL of the destination link.
     /// </summary>
     [Column("DestinationFragment")]
+    [NullSetting(NullSetting = NullSettings.Null)]
     public string? DestinationFragment { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the destination link.
     /// </summary>
     [Column("DestinationName")]
+    [NullSetting(NullSetting = NullSettings.Null)]
     public string? DestinationName { get; set; }
 
     /// <summary>
     /// Gets or sets the culture of the destination link. Used when the destination is a content node that varies by culture.
     /// </summary>
     [Column("DestinationCulture")]
+    [NullSetting(NullSetting = NullSettings.Null)]
     public string? DestinationCulture { get; set; }
 
     /// <summary>


### PR DESCRIPTION
This PR fixes issues with the `NullableColumnsMigration` running in SQLite, which should complete #225, or at least the issues with fresh installs.

The issue is that SQLite doesn't have support for altering a table to change column nullability. To get around this, I've introduced some branching logic that only runs for SQLite. In that instance, it makes a new table with the correct schema and copies all the data from the original table into it. 

It appears that Umbraco's migration runner doesn't actual look at the C# type level to determine nullability and instead requires the use of the `NullSettingAttribute`, which I used in `RedirectDto` to ensure that the `CreateTable<T>` call produces the correct schema.

Happy to make any changes or adjustments to better fit the style of the project