### PR TITLE
Hotfix for selecting pages with missing variants

### DIFF
--- a/src/Skybrud.Umbraco.Redirects/wwwroot/Elements/Destination.js
+++ b/src/Skybrud.Umbraco.Redirects/wwwroot/Elements/Destination.js
@@ -81,7 +81,7 @@ function fromContent(value, content) {
         key: content.id,
         name: content.variants[0].name,
         icon: content.documentType.icon,
-        url: content.url,
+        url: content.urls.find(x => x),
         cultures: content.variants.filter(x => x.culture).map(x => x.culture),
         null: false,
         trashed: content.isTrashed,
@@ -210,7 +210,7 @@ export class RedirectsDestinationElement extends UmbElementMixin(LitElement) {
                 return;
             }
 
-            if (!value.link.url) {
+            if (value.link.type !== "document" && !value.link.url) {
                 alert("No link URL");
                 return;
             }
@@ -219,7 +219,14 @@ export class RedirectsDestinationElement extends UmbElementMixin(LitElement) {
 
                 case "document":
                     RedirectsService.getContent(value.link.unique).then(function (res) {
-                        self.value = fromContent(value.link, res.data);
+                        const link = fromContent(value.link, res.data);
+                        if (link.url) {
+                            self.value = link;
+                        }
+                        else {
+                            alert("No URL for content");
+                            return;
+                        }
                     });
                     break;
 


### PR DESCRIPTION
We had a situation on a multilingual site, where the core link picker was always showing in one language.

Because of this, it was impossible to select destination pages not published in that language, as they obviously don't have a URL.

To fix, I changed the url check, to only run if the destionation type is not content. And if it's content, it will try to find another variant url. If it still fails, it will fail just like before.

With this in place, we were able to add the redirects we needed :)